### PR TITLE
Use Python 3.11 for `autopep8`

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,18 +19,6 @@ jobs:
     - run: pip install nox
     - run: nox -s test
 
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v4
-      with:
-        python-version: ${{ env.PYTHON_VERSION }}
-        cache: 'pip'
-        cache-dependency-path: requirements/test.txt
-    - run: pip install nox
-    - run: nox -s lint
-
   pip_compile:
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,50 +1,51 @@
 default_language_version:
-    python: python3.12
+  python: python3.12
 repos:
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.1.3
-  hooks:
-    - id: ruff
-      args: [--fix, --show-fixes]
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.3
+    hooks:
+      - id: ruff
+        args: [--fix, --show-fixes]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:
-    -   id: check-merge-conflict
-    -   id: check-yaml
-    -   id: debug-statements
-    -   id: end-of-file-fixer
-    -   id: mixed-line-ending
-    -   id: name-tests-test
--   repo: https://github.com/asottile/pyupgrade
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: debug-statements
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: name-tests-test
+  - repo: https://github.com/asottile/pyupgrade
     rev: v3.15.0
     hooks:
-    -   id: pyupgrade
+      - id: pyupgrade
         args: [--py311-plus]
--   repo: https://github.com/hhatto/autopep8
+  - repo: https://github.com/hhatto/autopep8
     rev: v2.0.4
     hooks:
-    -   id: autopep8
--   repo: https://github.com/asottile/reorder-python-imports
+      - id: autopep8
+        language_version: "3.11"
+  - repo: https://github.com/asottile/reorder-python-imports
     rev: v3.12.0
     hooks:
-    -   id: reorder-python-imports
-        args: [--py37-plus, --add-import, 'from __future__ import annotations']
--   repo: https://github.com/asottile/add-trailing-comma
+      - id: reorder-python-imports
+        args: [--py37-plus, --add-import, "from __future__ import annotations"]
+  - repo: https://github.com/asottile/add-trailing-comma
     rev: v3.1.0
     hooks:
-    -   id: add-trailing-comma
--   repo: https://github.com/asottile/yesqa
+      - id: add-trailing-comma
+  - repo: https://github.com/asottile/yesqa
     rev: v1.5.0
     hooks:
-    -   id: yesqa
+      - id: yesqa
         additional_dependencies: [flake8-bugbear]
--   repo: https://github.com/PyCQA/flake8
-    rev: '6.1.0'
+  - repo: https://github.com/PyCQA/flake8
+    rev: "6.1.0"
     hooks:
-    -   id: flake8
+      - id: flake8
         additional_dependencies: [flake8-bugbear]
--   repo: https://github.com/pre-commit/mirrors-mypy
+  - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.6.1
     hooks:
-    -   id: mypy
+      - id: mypy
         additional_dependencies: [attrs, cattrs, django-stubs, nox]


### PR DESCRIPTION
This tool requires `lib2to3` and so cannot be used with pre-commit.ci on
Python 3.12.
